### PR TITLE
docker run -v Warnings

### DIFF
--- a/CI/git_cleanup.sh
+++ b/CI/git_cleanup.sh
@@ -29,6 +29,6 @@
 # DM23-2165
 # </legal>
 
-
-docker run --rm  -v ${PWD}:/host  --workdir /host  docker.cc.cert.org/redemption/prereq \
-  git -c safe.directory='*'  clean -dfx
+>[!WARNING]
+docker run --rm -v ${PWD}:/host --workdir /host docker.cc.cert.org/redemption/prereq \
+	git -c safe.directory='*' clean -dfx

--- a/CI/run_tests.sh
+++ b/CI/run_tests.sh
@@ -28,20 +28,19 @@
 #
 # DM23-2165
 # </legal>
-
-
-docker run --rm  -v ${PWD}:/host  --workdir /host  docker.cc.cert.org/redemption/prereq \
-       rm junit.basic.xml junit.oss.xml junit.clang.xml ; \
-       echo cleaned
-
-docker run --rm  -v ${PWD}:/host  --workdir /host/code/acr/test  docker.cc.cert.org/redemption/prereq \
-       pytest --verbose --junit-xml=junit.basic.xml ; \
-       echo basic pytest done
-
-docker run --rm  -v ${PWD}:/host  --workdir /host/code/acr/test/ast  docker.cc.cert.org/redemption/prereq \
-       pytest --verbose --junit-xml=junit.clang.xml -s ast_comparer.py --config scenarios.json ; \
-       echo clang pytest done
-
-docker run --rm  -v ${PWD}:/host  --workdir /host/data/test  docker.cc.cert.org/redemption/test \
-       pytest --verbose --junit-xml=junit.oss.xml ; \
-       echo oss pytest done
+>[!WARNING]
+docker run --rm -v ${PWD}:/host --workdir /host docker.cc.cert.org/redemption/prereq \
+	rm junit.basic.xml junit.oss.xml junit.clang.xml
+echo cleaned
+>[!WARNING]
+docker run --rm -v ${PWD}:/host --workdir /host/code/acr/test docker.cc.cert.org/redemption/prereq \
+	pytest --verbose --junit-xml=junit.basic.xml
+echo basic pytest done
+>[!WARNING]
+docker run --rm -v ${PWD}:/host --workdir /host/code/acr/test/ast docker.cc.cert.org/redemption/prereq \
+	pytest --verbose --junit-xml=junit.clang.xml -s ast_comparer.py --config scenarios.json
+echo clang pytest done
+[!WARNING]
+docker run --rm -v ${PWD}:/host --workdir /host/data/test docker.cc.cert.org/redemption/test \
+	pytest --verbose --junit-xml=junit.oss.xml
+echo oss pytest done

--- a/CI/update_markings_tests.sh
+++ b/CI/update_markings_tests.sh
@@ -29,10 +29,11 @@
 # DM23-2165
 # </legal>
 
-
-docker run --rm  -v ${PWD}:/host  --workdir /host  docker.cc.cert.org/redemption/prereq \
-       rm junit.markings.xml ; \
-       echo cleaned
-docker run --rm  -v ${PWD}:/host  --workdir /host  docker.cc.cert.org/redemption/prereq \
-       pytest --junit-xml=junit.markings.xml -v update_markings.py ; \
-       echo markings pytest done
+>[!WARNING]
+docker run --rm -v ${PWD}:/host --workdir /host docker.cc.cert.org/redemption/prereq \
+	rm junit.markings.xml
+echo cleaned
+>[!WARNING]
+docker run --rm -v ${PWD}:/host --workdir /host docker.cc.cert.org/redemption/prereq \
+	pytest --junit-xml=junit.markings.xml -v update_markings.py
+echo markings pytest done

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ bear -- make
 
 To enable the Redemption container to run repairs on your local code directories, you should volume-share them with `-v` when you launch the container.  For example, to volume-share a local directory `/code`:
 
-`docker run -it --rm -v /code:/myCode docker.cc.cert.org/redemption/distrib  bash`
+`docker run -it --rm -v /<host_dir>:/home/host_code docker.cc.cert.org/redemption/distrib  bash`
 
 See https://docs.docker.com/storage/volumes/ for more information on volume-sharing.
 See https://docs.docker.com/reference/cli/docker/container/run/ for more information about options using the `docker run` command.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker run -it --rm docker.cc.cert.org/redemption/distrib  bash
 
 Note that this container contains the entire Redemption code...this is useful if you intend to run Redemption, but have no plans to modify or tweak the code.  If you plan to modify the code, use the `prereq` container instead:
 
-```sh
+> [!WARNING]
 docker run -it --rm -v ${PWD}:/host -w /host  docker.cc.cert.org/redemption/prereq  bash
 ```
 
@@ -102,6 +102,7 @@ There is a `test` Docker container that you can build and test with. It builds `
 
 ```sh
 docker  build  -f Dockerfile.test  -t docker.cc.cert.org/redemption/test  .
+> [!WARNING]
 docker run -it --rm -v ${PWD}:/host -w /host docker.cc.cert.org/redemption/test  bash
 ```
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ bear -- make
 
 To enable the Redemption container to run repairs on your local code directories, you should volume-share them with `-v` when you launch the container.  For example, to volume-share a local directory `/code`:
 
-`docker run -it --rm -v /<host_dir>:/home/host_code docker.cc.cert.org/redemption/distrib  bash`
+`docker run -it --rm -v /<host_dir>:/host/host_code docker.cc.cert.org/redemption/distrib  bash`
 
 See https://docs.docker.com/storage/volumes/ for more information on volume-sharing.
 See https://docs.docker.com/reference/cli/docker/container/run/ for more information about options using the `docker run` command.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ docker run -it --rm docker.cc.cert.org/redemption/distrib  bash
 Note that this container contains the entire Redemption code...this is useful if you intend to run Redemption, but have no plans to modify or tweak the code.  If you plan to modify the code, use the `prereq` container instead:
 
 > [!WARNING]
+```sh
 docker run -it --rm -v ${PWD}:/host -w /host  docker.cc.cert.org/redemption/prereq  bash
 ```
 

--- a/data/README.dataset.md
+++ b/data/README.dataset.md
@@ -49,11 +49,13 @@ First, build both Docker containers. Then run the first one.
 
 ``` shell
 docker build -f Dockerfile.rosecheckers -t data_container .
+> [!WARNING]
 docker run -it --rm -v ${PWD}:/host -v ${PWD}/datasets:/datasets  -w /host data_container bash
 ```
 
 ``` shell
 docker build -f Dockerfile.redemption  -t clang_tidy_data_container .
+> [!WARNING]
 docker run -it --rm -v ${PWD}:/host -v ${PWD}/datasets:/datasets  -w /host clang_tidy_data_container bash
 ```
 

--- a/doc/examples/codebase/README.md
+++ b/doc/examples/codebase/README.md
@@ -53,6 +53,7 @@ You can try to repair other codebases, or other versions of the `dos2unix` codeb
 For the rest of these instructions, you should execute the commands inside the `distrib` Docker container, and `cd` into this directory.  To set this up, run this command in the top-level Redemption directory:
 
 > [!WARNING]
+``` sh
 docker run -it --rm  -v ${PWD}:/host  docker.cc.cert.org/redemption/distrib  bash
 ```
 

--- a/doc/examples/codebase/README.md
+++ b/doc/examples/codebase/README.md
@@ -52,7 +52,7 @@ You can try to repair other codebases, or other versions of the `dos2unix` codeb
 
 For the rest of these instructions, you should execute the commands inside the `distrib` Docker container, and `cd` into this directory.  To set this up, run this command in the top-level Redemption directory:
 
-``` sh
+> [!WARNING]
 docker run -it --rm  -v ${PWD}:/host  docker.cc.cert.org/redemption/distrib  bash
 ```
 

--- a/doc/regression_tests.md
+++ b/doc/regression_tests.md
@@ -100,6 +100,7 @@ There is also a `test` Docker container that you can build and test with. It bui
 
 ```sh
 docker  build  -f Dockerfile.test  -t docker.cc.cert.org/redemption/test  .
+> [!WARNING]
 docker run -it --rm -v ${PWD}:/host -w /host docker.cc.cert.org/redemption/test  bash
 ```
 


### PR DESCRIPTION
I found 13 instances where "docker run --rm -v ${PWD}:/host" or something similar exist in the redemption project.

I put a [!WARNING] one line above all occurrences to make these easy to find.

I might be wrong, but I think mounting to /host in the redemption docker may cause some issues. 

I'll demonstrate an example:
Lets say I have a report.xml file from cppchecker and I want to run alerts2input.py

I will run the command:
`sudo docker run -it --rm -v ~/Downloads/myCode/:/host -w /host  docker.cc.cert.org/redemption/prereq  bash`
![Screenshot from 2024-06-12 15-51-29](https://github.com/cmu-sei/redemption/assets/79768202/fbe82bd4-8daf-443b-b922-baef0bfc7c02)
As you can see from the above picture, it's not possible to go to /host/code/analysis/alerts2input.py because the /host directory is replaced with the myCode directory.